### PR TITLE
Added filter for color inline styles.

### DIFF
--- a/includes/abstracts/abstract-social-count-plus-counter.php
+++ b/includes/abstracts/abstract-social-count-plus-counter.php
@@ -71,12 +71,13 @@ abstract class Social_Count_Plus_Counter {
 	protected function get_view_li( $slug, $url, $count, $title, $color, $settings ) {
 		$target_blank = isset( $settings['target_blank'] ) ? ' target="_blank"' : '';
 		$rel_nofollow = isset( $settings['rel_nofollow'] ) ? ' rel="nofollow"' : '';
+		$custom_color = ! empty( $color ) ? ' style="color: '. $color .' !important;"' : '';
 
 		$html = sprintf( '<li class="count-%s">', $slug );
 			$html .= sprintf( '<a class="icon" href="%s"%s%s></a>', esc_url( $url ), $target_blank, $rel_nofollow );
 			$html .= '<span class="items">';
-				$html .= sprintf( '<span class="count" style="color: %s !important;">%s</span>', $color, apply_filters( 'social_count_plus_number_format', $count ) );
-				$html .= sprintf( '<span class="label" style="color: %s !important;">%s</span>', $color, $title );
+				$html .= sprintf( '<span class="count"%s>%s</span>', apply_filters( 'social_count_plus_custom_color', $custom_color ), apply_filters( 'social_count_plus_number_format', $count ) );
+				$html .= sprintf( '<span class="label"%s>%s</span>', apply_filters( 'social_count_plus_custom_color', $custom_color ), $title );
 			$html .= '</span>';
 		$html .= '</li>';
 


### PR DESCRIPTION
Hi Claudio, 

Last week I opened discussion https://wordpress.org/support/topic/important-in-style-attribute, and I wanted to be able to disable inline color styles via simple filter.

I also added check if $color is empty, so empty inline rules like this `style="color:  !important;"` won't show if you click "clear" on color picker in plugin settings.

With this, theme authors can disable inline styles, and widget text will inherit styles from theme style.css. Hope you'll merge this. 

Best regards,
Sinisa Nikolic